### PR TITLE
Add support for removing body files, implements #1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ These will be placed in `build/libs/`.
 
 Standalone server:
 ```sh
-java -jar build/libs/wiremock-unused-stubs-extension-0.2-standalone.jar
+java -jar build/libs/wiremock-unused-stubs-extension-0.3-standalone.jar
 ```
 
 With WireMock standalone JAR:
 ```sh
 wget -nc http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.14.0/wiremock-standalone-2.14.0.jar
 java \
-        -cp wiremock-standalone-2.14.0.jar:build/libs/wiremock-unused-stubs-extension-0.2.jar \
+        -cp wiremock-standalone-2.14.0.jar:build/libs/wiremock-unused-stubs-extension-0.3.jar \
         com.github.tomakehurst.wiremock.standalone.WireMockServerRunner \
         --extensions="com.github.masonm.wiremock.UnusedStubsAdminExtension"
 ```
@@ -34,6 +34,7 @@ new WireMockServer(wireMockConfig()
 
 # Usage
 
-Call `GET /__admin/unused_mappings` to retrieve an array of stub mappings that have not matched any requests in the request journal. Call `DELETE /__admin/unused_mappings` to remove all such stub mappings.
+* Call `GET /__admin/unused_mappings` to retrieve an array of stub mappings that have not matched any requests in the request journal.
+* Call `DELETE /__admin/unused_mappings` to remove all such stub mappings. By default, any body files used by the stub mapppings (typically stored in the "__files" directory) will preserved. To remove those too, pass "remove_files" in the query, i.e. `DELETE /__admin/unused_mappings?remove_files`
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 sourceCompatibility = 1.8
 group = 'com.github.masonm'
 archivesBaseName = 'wiremock-unused-stubs-extension'
-version = '0.2'
+version = '0.3'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/github/masonm/wiremock/UnusedStubsAdminExtension.java
+++ b/src/main/java/com/github/masonm/wiremock/UnusedStubsAdminExtension.java
@@ -2,16 +2,19 @@ package com.github.masonm.wiremock;
 
 import com.github.tomakehurst.wiremock.admin.Router;
 import com.github.tomakehurst.wiremock.admin.model.PathParams;
+import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.AdminApiExtension;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.DELETE;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
 import static com.github.tomakehurst.wiremock.http.ResponseDefinition.ok;
@@ -33,36 +36,73 @@ public class UnusedStubsAdminExtension implements AdminApiExtension {
         // Can't use "/mappings/unused" as the route because that'll match "/mappings/{id}"
         router.add(GET, "/unused_mappings",
             (Admin admin, Request request, PathParams pathParams) ->
-                okForJson(getUnusedMappings(admin).toArray())
+                okForJson(getStubMappingsPartitionedByUsage(admin).get(false).toArray())
         );
 
         router.add(DELETE, "/unused_mappings",
             (Admin admin, Request request, PathParams pathParams) -> {
-                getUnusedMappings(admin).forEach(admin::removeStubMapping);
+                deleteUnusedStubMappings(admin, request);
                 return ok();
             }
         );
     }
 
     /**
-     * Finds all stub mappings that haven't matched any of the ServeEvents in the request journal.
+     * Delete stub mappings that haven't matched any requests in the request journal
+     * @param admin Wiremock-provided Admin object
+     * @param request Request object
+     */
+    private void deleteUnusedStubMappings(Admin admin, Request request) {
+        boolean removeFiles = request.queryParameter("remove_files").isPresent();
+        final Map<Boolean, List<StubMapping>> mappings = getStubMappingsPartitionedByUsage(admin);
+        mappings.get(false).forEach(admin::removeStubMapping);
+
+        if (removeFiles) {
+            final FileSource root = admin.getOptions().filesRoot().child(FILES_ROOT);
+            final Set<String> bodyFilesForMatchedStubs = mappings
+                .get(true)
+                .stream()
+                .map(stub -> stub.getResponse().getBodyFileName())
+                .collect(Collectors.toSet());
+            mappings
+                .get(false)
+                .stream()
+                .map(stub -> stub.getResponse().getBodyFileName())
+                // Since stub mappings can share body files, we have to check to
+                // see if any of the remaining stubs are using it
+                .filter(fileName -> fileName != null && !bodyFilesForMatchedStubs.contains(fileName))
+                .forEach(root::deleteFile);
+        }
+    }
+
+    /**
+     * Return set of stub mapping UUIDs that have matched at least one request in the journal
      *
      * @param admin Wiremock-provided Admin object
-     * @return Stream of unmatched StubMappings
+     * @return Set of UUIDs
      */
-    private Stream<StubMapping> getUnusedMappings(Admin admin) {
-        final Set<UUID> servedStubIds = admin
+    private Set<UUID> getServedStubIds(Admin admin) {
+        return admin
             .getServeEvents()
             .getRequests()
             .stream()
             .filter(event -> event.getStubMapping() != null)
             .map(event -> event.getStubMapping().getId())
             .collect(Collectors.toSet());
+    }
 
+    /**
+     * Finds all stub mappings that haven't matched any of the ServeEvents in the request journal.
+     *
+     * @param admin Wiremock-provided Admin object
+     * @return Map of StubMappings partitioned by whether they match any events in the journal
+     */
+    private Map<Boolean, List<StubMapping>> getStubMappingsPartitionedByUsage(Admin admin) {
+        Set<UUID> servedStubIds = getServedStubIds(admin);
         return admin
             .listAllStubMappings()
             .getMappings()
             .stream()
-            .filter(stub -> !servedStubIds.contains(stub.getId()));
+            .collect(Collectors.partitioningBy(stub -> servedStubIds.contains(stub.getId())));
     }
 }

--- a/src/test/java/com/github/masonm/wiremock/GetUnusedMappingsAcceptanceTest.java
+++ b/src/test/java/com/github/masonm/wiremock/GetUnusedMappingsAcceptanceTest.java
@@ -27,7 +27,7 @@ public class GetUnusedMappingsAcceptanceTest extends UnusedMappingsAcceptanceTes
 
     @Test
     public void withMultipleMappings() {
-        StubMapping stub1 = stubFor(get(urlEqualTo("/stub-1")));
+        stubFor(get(urlEqualTo("/stub-1")));
         StubMapping stub2 = stubFor(get(urlEqualTo("/stub-2")));
 
         assertThat(testClient.get("/stub-1").statusCode(), is(HTTP_OK));

--- a/src/test/java/com/github/masonm/wiremock/RemoveUnusedMappingsAcceptanceTest.java
+++ b/src/test/java/com/github/masonm/wiremock/RemoveUnusedMappingsAcceptanceTest.java
@@ -1,14 +1,16 @@
 package com.github.masonm.wiremock;
 
+import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import org.junit.Test;
 
 import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
+import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.*;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 public class RemoveUnusedMappingsAcceptanceTest extends UnusedMappingsAcceptanceTestBase {
@@ -19,7 +21,7 @@ public class RemoveUnusedMappingsAcceptanceTest extends UnusedMappingsAcceptance
 
     @Test
     public void withOneUnusedMapping() {
-        StubMapping stub1 = stubFor(get(urlEqualTo("/stub-1")));
+        stubFor(get(urlEqualTo("/stub-1")));
         assertThat(listAllStubMappings().getMappings().size(), is(1));
 
         assertThat(testClient.delete(ADMIN_URL).statusCode(), is(HTTP_OK));
@@ -28,7 +30,7 @@ public class RemoveUnusedMappingsAcceptanceTest extends UnusedMappingsAcceptance
 
     @Test
     public void withOneUsedMapping() {
-        StubMapping stub1 = stubFor(get(urlEqualTo("/stub-1")));
+        stubFor(get(urlEqualTo("/stub-1")));
         assertThat(testClient.get("/stub-1").statusCode(), is(HTTP_OK));
 
         assertThat(testClient.delete(ADMIN_URL).statusCode(), is(HTTP_OK));
@@ -36,16 +38,69 @@ public class RemoveUnusedMappingsAcceptanceTest extends UnusedMappingsAcceptance
     }
 
     @Test
+    public void withOneUnusedMappingAndRemoveFiles() {
+        stubFor(get(urlEqualTo("/stub-1")));
+
+        assertThat(testClient.delete(ADMIN_URL_REMOVE_FILES).statusCode(), is(HTTP_OK));
+        assertThat(listAllStubMappings().getMappings().size(), is(0));
+    }
+
+    @Test
     public void withMultipleMappings() {
         UUID id1 = UUID.randomUUID();
-        UUID id2 = UUID.randomUUID();
         StubMapping stub1 = stubFor(get(urlEqualTo("/stub-1")).withId(id1));
-        stubFor(get(urlEqualTo("/stub-2")).withId(id2));
+        stubFor(get(urlEqualTo("/stub-2")).withId(UUID.randomUUID()));
 
         assertThat(testClient.get("/stub-1").statusCode(), is(HTTP_OK));
 
         assertThat(testClient.delete(ADMIN_URL).statusCode(), is(HTTP_OK));
         assertThat(getSingleStubMapping(id1), is(stub1));
         assertThat(listAllStubMappings().getMappings().size(), is(1));
+    }
+
+    @Test
+    public void withMultipleMappingsWithSeparateFilesAndRemoveFiles() {
+        FileSource fileSource = wireMockServer.getOptions().filesRoot().child(FILES_ROOT);
+        fileSource.createIfNecessary();
+        fileSource.writeTextFile("mapping-one", "should be removed");
+        fileSource.writeTextFile("mapping-two", "should be removed");
+
+        stubFor(get(urlEqualTo("/stub-1")).willReturn(aResponse().withBodyFile("mapping-one")));
+        stubFor(get(urlEqualTo("/stub-2")).willReturn(aResponse().withBodyFile("mapping-two")));
+
+        assertThat(testClient.delete(ADMIN_URL_REMOVE_FILES).statusCode(), is(HTTP_OK));
+
+        assertThat(listAllStubMappings().getMappings().size(), is(0));
+        assertThat(fileSource.listFilesRecursively(), hasExactly());
+    }
+
+    @Test
+    public void withMultipleMappingsWithSharedFilesAndRemoveFiles() {
+        FileSource fileSource = wireMockServer.getOptions().filesRoot().child(FILES_ROOT);
+        fileSource.createIfNecessary();
+        fileSource.writeTextFile("shared-mapping", "should be preserved");
+
+        UUID id1 = UUID.randomUUID();
+        StubMapping stub1 = stubFor(
+            get(urlEqualTo("/stub-1"))
+                .withId(id1)
+                .willReturn(aResponse().withBodyFile("shared-mapping"))
+        );
+        assertThat(testClient.get("/stub-1").statusCode(), is(HTTP_OK));
+
+        stubFor(
+            get(urlEqualTo("/stub-2"))
+                .withId(UUID.randomUUID())
+                .willReturn(aResponse().withBodyFile("shared-mapping"))
+        );
+
+        assertThat(testClient.delete(ADMIN_URL_REMOVE_FILES).statusCode(), is(HTTP_OK));
+
+        assertThat(getSingleStubMapping(id1), is(stub1));
+        assertThat(listAllStubMappings().getMappings().size(), is(1));
+        // Should not have remove file since it's shared with an existing mapping
+        assertThat(fileSource.listFilesRecursively(), hasExactly(
+            fileNamed(stub1.getResponse().getBodyFileName())
+        ));
     }
 }

--- a/src/test/java/com/github/masonm/wiremock/UnusedMappingsAcceptanceTestBase.java
+++ b/src/test/java/com/github/masonm/wiremock/UnusedMappingsAcceptanceTestBase.java
@@ -7,6 +7,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 
 public class UnusedMappingsAcceptanceTestBase extends AcceptanceTestBase {
     protected static final String ADMIN_URL = "/__admin/unused_mappings";
+    protected static final String ADMIN_URL_REMOVE_FILES = ADMIN_URL + "?remove_files";
 
     @BeforeClass
     public static void setupServer() {

--- a/test-script.sh
+++ b/test-script.sh
@@ -13,21 +13,22 @@ results() {
 	echo -e "UNUSED:"; curl http://localhost:$PORT/__admin/unused_mappings
 	curl -s -X DELETE http://localhost:$PORT/__admin/unused_mappings
 	echo -e "\n\nAFTER DELETE:"; curl http://localhost:$PORT/__admin/mappings
-	reset
 }
 
 
 echo -e "Trying with no requests (should delete both):"
 results
+reset
 
 echo -e "\n\nTrying with one matching request (should delete bar):"
 curl -s http://localhost:$PORT/foo > /dev/null
 curl -s http://localhost:$PORT/baz > /dev/null
 results
+reset
 
 echo -e "\n\nTrying with both requests matching (should not delete any):"
-
 curl -s http://localhost:$PORT/foo > /dev/null
 curl -s http://localhost:$PORT/baz > /dev/null
 curl -s http://localhost:$PORT/bar > /dev/null
 results
+reset

--- a/wiremock-unused-stubs-extension.iml
+++ b/wiremock-unused-stubs-extension.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="wiremock-unused-stubs-extension" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="com.github.masonm" external.system.module.version="0.2" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="wiremock-unused-stubs-extension" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="com.github.masonm" external.system.module.version="0.3" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">


### PR DESCRIPTION
This adds support for removing body files when `DELETE /__admin/unused_mappings` is called by adding a new query parameter, "remove_files", as requested in https://github.com/MasonM/wiremock-unused-stubs-extension/issues/1

This was complicated by the fact that multiple stub mappings can share the same body file, so I included a check to make sure we don't remove a file that's used by one of the matching stubs.